### PR TITLE
Fix for read error while reading the user credentials

### DIFF
--- a/GinClientApp/UserCredentials.cs
+++ b/GinClientApp/UserCredentials.cs
@@ -47,6 +47,9 @@ namespace GinClientApp
                     _instance = JsonConvert.DeserializeObject<UserCredentials>(text);
                 }
 
+                if (string.IsNullOrEmpty(_instance.Username) || string.IsNullOrEmpty(_instance.Password))
+                    return false;
+
                 return true;
             }
             catch


### PR DESCRIPTION
Under certain conditions, the UserCredentials.json file can become corrupted, this adds sanity checking on read.