### PR TITLE
Fix for nonexisting/inaccessible repos

### DIFF
--- a/GinClientApp/Dialogs/MetroCreateNewRepoDlg.cs
+++ b/GinClientApp/Dialogs/MetroCreateNewRepoDlg.cs
@@ -7,6 +7,7 @@ using GinClientLibrary;
 using GinClientLibrary.Extensions;
 using MetroFramework;
 using MetroFramework.Forms;
+using Newtonsoft.Json;
 
 namespace GinClientApp.Dialogs
 {
@@ -42,6 +43,17 @@ namespace GinClientApp.Dialogs
 
         private bool CheckSanity()
         {
+            var repoListJson = _appContext.ServiceClient.GetRemoteRepositoryList();
+            var repoList = JsonConvert.DeserializeObject<RepositoryListing[]>(repoListJson);
+            var paths = repoList.Select(repoListing => repoListing.full_name).ToList();
+
+            if (!paths.Exists(path => path == mTxBRepoAddress.Text))
+            {
+                MetroMessageBox.Show(this, Resources.Options_CheckSanity_No_private_or_shared_repos,
+                    Resources.GinClientApp_Gin_Client_Warning, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+
             if (string.IsNullOrEmpty(mTxBRepoAddress.Text))
             {
                 MetroMessageBox.Show(this, Resources.Options_CheckSanity_No_checkout_address_has_been_entered_,

--- a/GinClientApp/Properties/Resources.Designer.cs
+++ b/GinClientApp/Properties/Resources.Designer.cs
@@ -329,6 +329,15 @@ namespace GinClientApp.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No private or shared repositories with this address exist.
+        /// </summary>
+        internal static string Options_CheckSanity_No_private_or_shared_repos {
+            get {
+                return ResourceManager.GetString("Options_CheckSanity_No_private_or_shared_repos", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The checkout directory {0} must be empty..
         /// </summary>
         internal static string Options_CheckSanity_The_checkout_address_is_not_empty {

--- a/GinClientApp/Properties/Resources.resx
+++ b/GinClientApp/Properties/Resources.resx
@@ -232,6 +232,9 @@ Copyright (c) Microsoft</value>
   <data name="Options_CheckSanity_No_checkout_address_has_been_entered_" xml:space="preserve">
     <value>No checkout address has been entered.</value>
   </data>
+  <data name="Options_CheckSanity_No_private_or_shared_repos" xml:space="preserve">
+    <value>No private or shared repositories with this address exist</value>
+  </data>
   <data name="Options_CheckSanity_The_checkout_address_is_not_properly_formatted" xml:space="preserve">
     <value>The checkout address is not properly formatted. Do you wish to create a new repository with the name {0} instead?</value>
   </data>


### PR DESCRIPTION
Attempts to check out non-existing or inaccessible repositories should be caught before trying to clone