### PR TITLE
Improved error handling when calling gin-cli

### DIFF
--- a/GinClientLibrary/GinRepository.cs
+++ b/GinClientLibrary/GinRepository.cs
@@ -307,6 +307,7 @@ namespace GinClientLibrary
             catch (Exception e)
             {
                 OnFileOperationError("Could not create checkout directory. Exception: " + e.Message + "\n InnerException: " + e.InnerException);
+                return false;
             }
 
             try
@@ -317,6 +318,7 @@ namespace GinClientLibrary
             catch (Exception e)
             {
                 OnFileOperationError("Could not create mountpoint directory. Exception: " + e.Message + "\n InnerException: " + e.InnerException);
+                return false;
             }
 
             if (PhysicalDirectory.IsEmpty())
@@ -349,7 +351,8 @@ namespace GinClientLibrary
                 if (result)
                     OnFileOperationCompleted(new FileOperationEventArgs {File = Address, Success = true});
                 else
-                { OnFileOperationError(error);
+                {
+                    OnFileOperationError(error);
                     return false;
                 }
             }
@@ -485,6 +488,12 @@ namespace GinClientLibrary
 
                 var output = Output.ToString();
                 Output.Clear();
+
+                if (process.ExitCode != 0 && string.IsNullOrEmpty(error))
+                {
+                    error = "gin-cli returned error code " + process.ExitCode;
+                }
+
                 return output;
             }
         }
@@ -515,6 +524,11 @@ namespace GinClientLibrary
                 process.BeginOutputReadLine();
                 error = process.StandardError.ReadToEnd();
                 process.WaitForExit();
+
+                if (process.ExitCode != 0 && string.IsNullOrEmpty(error))
+                {
+                    error = "gin-cli returned error code " + process.ExitCode;
+                }
             }
         }
 


### PR DESCRIPTION
If gin-cli fails but stderr is not written to (see gin-cli issue 186), check the return value and return that as the error string