### PR TITLE
Fixes a few issues with the shell extension

### DIFF
--- a/GinClientApp/Connected Services/GinService/Reference.cs
+++ b/GinClientApp/Connected Services/GinService/Reference.cs
@@ -165,6 +165,12 @@ namespace GinClientApp.GinService {
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/DownloadFiles", ReplyAction="http://tempuri.org/IGinService/DownloadFilesResponse")]
         System.Threading.Tasks.Task DownloadFilesAsync(string[] filePaths);
         
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/RemoveLocalContent", ReplyAction="http://tempuri.org/IGinService/RemoveLocalContentResponse")]
+        void RemoveLocalContent(string[] filePaths);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/RemoveLocalContent", ReplyAction="http://tempuri.org/IGinService/RemoveLocalContentResponse")]
+        System.Threading.Tasks.Task RemoveLocalContentAsync(string[] filePaths);
+        
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/GetGinCliVersion", ReplyAction="http://tempuri.org/IGinService/GetGinCliVersionResponse")]
         string GetGinCliVersion();
         
@@ -188,6 +194,12 @@ namespace GinClientApp.GinService {
         
         [System.ServiceModel.OperationContractAttribute(IsOneWay=true, IsTerminating=true, Action="http://tempuri.org/IGinService/EndSession")]
         System.Threading.Tasks.Task EndSessionAsync();
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/IsAlive", ReplyAction="http://tempuri.org/IGinService/IsAliveResponse")]
+        bool IsAlive();
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/IsAlive", ReplyAction="http://tempuri.org/IGinService/IsAliveResponse")]
+        System.Threading.Tasks.Task<bool> IsAliveAsync();
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.ServiceModel", "4.0.0.0")]
@@ -434,6 +446,14 @@ namespace GinClientApp.GinService {
             return base.Channel.DownloadFilesAsync(filePaths);
         }
         
+        public void RemoveLocalContent(string[] filePaths) {
+            base.Channel.RemoveLocalContent(filePaths);
+        }
+        
+        public System.Threading.Tasks.Task RemoveLocalContentAsync(string[] filePaths) {
+            return base.Channel.RemoveLocalContentAsync(filePaths);
+        }
+        
         public string GetGinCliVersion() {
             return base.Channel.GetGinCliVersion();
         }
@@ -464,6 +484,14 @@ namespace GinClientApp.GinService {
         
         public System.Threading.Tasks.Task EndSessionAsync() {
             return base.Channel.EndSessionAsync();
+        }
+        
+        public bool IsAlive() {
+            return base.Channel.IsAlive();
+        }
+        
+        public System.Threading.Tasks.Task<bool> IsAliveAsync() {
+            return base.Channel.IsAliveAsync();
         }
     }
 }

--- a/GinClientApp/Connected Services/GinService/service1.wsdl
+++ b/GinClientApp/Connected Services/GinService/service1.wsdl
@@ -1207,6 +1207,52 @@
       </wsp:All>
     </wsp:ExactlyOne>
   </wsp:Policy>
+  <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_RemoveLocalContent_Input_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+          <sp:Header Name="Sequence" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="SequenceAcknowledgement" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="AckRequested" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="ChannelInstance" Namespace="http://schemas.microsoft.com/ws/2005/02/duplex" />
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing" />
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_RemoveLocalContent_output_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+          <sp:Header Name="Sequence" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="SequenceAcknowledgement" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="AckRequested" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="ChannelInstance" Namespace="http://schemas.microsoft.com/ws/2005/02/duplex" />
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing" />
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
   <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_GetGinCliVersion_Input_policy">
     <wsp:ExactlyOne>
       <wsp:All>
@@ -1323,6 +1369,52 @@
     </wsp:ExactlyOne>
   </wsp:Policy>
   <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_EndSession_Input_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+          <sp:Header Name="Sequence" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="SequenceAcknowledgement" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="AckRequested" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="ChannelInstance" Namespace="http://schemas.microsoft.com/ws/2005/02/duplex" />
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing" />
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_IsAlive_Input_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+          <sp:Header Name="Sequence" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="SequenceAcknowledgement" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="AckRequested" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="ChannelInstance" Namespace="http://schemas.microsoft.com/ws/2005/02/duplex" />
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing" />
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_IsAlive_output_policy">
     <wsp:ExactlyOne>
       <wsp:All>
         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
@@ -1590,6 +1682,12 @@
   <wsdl:message name="IGinService_DownloadFiles_OutputMessage">
     <wsdl:part name="parameters" element="tns:DownloadFilesResponse" />
   </wsdl:message>
+  <wsdl:message name="IGinService_RemoveLocalContent_InputMessage">
+    <wsdl:part name="parameters" element="tns:RemoveLocalContent" />
+  </wsdl:message>
+  <wsdl:message name="IGinService_RemoveLocalContent_OutputMessage">
+    <wsdl:part name="parameters" element="tns:RemoveLocalContentResponse" />
+  </wsdl:message>
   <wsdl:message name="IGinService_GetGinCliVersion_InputMessage">
     <wsdl:part name="parameters" element="tns:GetGinCliVersion" />
   </wsdl:message>
@@ -1607,6 +1705,12 @@
   </wsdl:message>
   <wsdl:message name="IGinService_EndSession_InputMessage">
     <wsdl:part name="parameters" element="tns:EndSession" />
+  </wsdl:message>
+  <wsdl:message name="IGinService_IsAlive_InputMessage">
+    <wsdl:part name="parameters" element="tns:IsAlive" />
+  </wsdl:message>
+  <wsdl:message name="IGinService_IsAlive_OutputMessage">
+    <wsdl:part name="parameters" element="tns:IsAliveResponse" />
   </wsdl:message>
   <wsdl:message name="IGinService_FileOperationStarted_OutputCallbackMessage">
     <wsdl:part name="parameters" element="tns:FileOperationStarted" />
@@ -1719,6 +1823,10 @@
       <wsdl:input wsaw:Action="http://tempuri.org/IGinService/DownloadFiles" message="tns:IGinService_DownloadFiles_InputMessage" />
       <wsdl:output wsaw:Action="http://tempuri.org/IGinService/DownloadFilesResponse" message="tns:IGinService_DownloadFiles_OutputMessage" />
     </wsdl:operation>
+    <wsdl:operation msc:isInitiating="true" msc:isTerminating="false" name="RemoveLocalContent">
+      <wsdl:input wsaw:Action="http://tempuri.org/IGinService/RemoveLocalContent" message="tns:IGinService_RemoveLocalContent_InputMessage" />
+      <wsdl:output wsaw:Action="http://tempuri.org/IGinService/RemoveLocalContentResponse" message="tns:IGinService_RemoveLocalContent_OutputMessage" />
+    </wsdl:operation>
     <wsdl:operation msc:isInitiating="true" msc:isTerminating="false" name="GetGinCliVersion">
       <wsdl:input wsaw:Action="http://tempuri.org/IGinService/GetGinCliVersion" message="tns:IGinService_GetGinCliVersion_InputMessage" />
       <wsdl:output wsaw:Action="http://tempuri.org/IGinService/GetGinCliVersionResponse" message="tns:IGinService_GetGinCliVersion_OutputMessage" />
@@ -1732,6 +1840,10 @@
     </wsdl:operation>
     <wsdl:operation msc:isInitiating="true" msc:isTerminating="true" name="EndSession">
       <wsdl:input wsaw:Action="http://tempuri.org/IGinService/EndSession" message="tns:IGinService_EndSession_InputMessage" />
+    </wsdl:operation>
+    <wsdl:operation msc:isInitiating="true" msc:isTerminating="false" name="IsAlive">
+      <wsdl:input wsaw:Action="http://tempuri.org/IGinService/IsAlive" message="tns:IGinService_IsAlive_InputMessage" />
+      <wsdl:output wsaw:Action="http://tempuri.org/IGinService/IsAliveResponse" message="tns:IGinService_IsAlive_OutputMessage" />
     </wsdl:operation>
     <wsdl:operation msc:isInitiating="true" msc:isTerminating="false" name="FileOperationStarted">
       <wsdl:output wsaw:Action="http://tempuri.org/IGinService/FileOperationStarted" message="tns:IGinService_FileOperationStarted_OutputCallbackMessage" />
@@ -2016,6 +2128,17 @@
         <soap12:body use="literal" />
       </wsdl:output>
     </wsdl:operation>
+    <wsdl:operation name="RemoveLocalContent">
+      <soap12:operation soapAction="http://tempuri.org/IGinService/RemoveLocalContent" style="document" />
+      <wsdl:input>
+        <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_RemoveLocalContent_Input_policy" />
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_RemoveLocalContent_output_policy" />
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
     <wsdl:operation name="GetGinCliVersion">
       <soap12:operation soapAction="http://tempuri.org/IGinService/GetGinCliVersion" style="document" />
       <wsdl:input>
@@ -2051,6 +2174,17 @@
         <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_EndSession_Input_policy" />
         <soap12:body use="literal" />
       </wsdl:input>
+    </wsdl:operation>
+    <wsdl:operation name="IsAlive">
+      <soap12:operation soapAction="http://tempuri.org/IGinService/IsAlive" style="document" />
+      <wsdl:input>
+        <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_IsAlive_Input_policy" />
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_IsAlive_output_policy" />
+        <soap12:body use="literal" />
+      </wsdl:output>
     </wsdl:operation>
     <wsdl:operation name="FileOperationStarted">
       <soap12:operation soapAction="http://tempuri.org/IGinService/FileOperationStarted" style="document" />

--- a/GinClientApp/Connected Services/GinService/service2.xsd
+++ b/GinClientApp/Connected Services/GinService/service2.xsd
@@ -330,6 +330,18 @@
       <xs:sequence />
     </xs:complexType>
   </xs:element>
+  <xs:element name="RemoveLocalContent">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element xmlns:q5="http://schemas.microsoft.com/2003/10/Serialization/Arrays" minOccurs="0" name="filePaths" nillable="true" type="q5:ArrayOfstring" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoveLocalContentResponse">
+    <xs:complexType>
+      <xs:sequence />
+    </xs:complexType>
+  </xs:element>
   <xs:element name="GetGinCliVersion">
     <xs:complexType>
       <xs:sequence />
@@ -365,6 +377,18 @@
   <xs:element name="EndSession">
     <xs:complexType>
       <xs:sequence />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IsAlive">
+    <xs:complexType>
+      <xs:sequence />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IsAliveResponse">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" name="IsAliveResult" type="xs:boolean" />
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="FileOperationStarted">

--- a/GinClientApp/GinApplicationContext.cs
+++ b/GinClientApp/GinApplicationContext.cs
@@ -215,6 +215,8 @@ namespace GinClientApp
                 MaxReceivedMessageSize = int.MaxValue,
                 OpenTimeout = TimeSpan.FromMinutes(1.0),
                 CloseTimeout = TimeSpan.FromMinutes(1.0),
+                SendTimeout = TimeSpan.FromHours(1),
+                ReceiveTimeout = TimeSpan.FromHours(1),
                 ReaderQuotas = new XmlDictionaryReaderQuotas
                 {
                     MaxArrayLength = int.MaxValue,

--- a/GinClientApp/ServiceComponent/GinService.cs
+++ b/GinClientApp/ServiceComponent/GinService.cs
@@ -232,6 +232,17 @@ namespace GinService
                 repo.RetrieveFile(file);
         }
 
+        void IGinService.RemoveLocalContent(IEnumerable<string> filePaths)
+        {
+            var files = filePaths as string[] ?? filePaths.ToArray();
+            var repo = RepositoryManager.Instance.GetRepoByPath(files.First());
+
+            foreach (var file in files)
+            {
+                repo.RemoveFile(file);
+            }
+        }
+
         string IGinService.GetGinCliVersion()
         {
             return RepositoryManager.Instance.GetGinCliVersion();
@@ -256,6 +267,11 @@ namespace GinService
         {
             RepositoryManager.Instance.UnmountAllRepositories();
             RepositoryManager.Instance.Logout();
+        }
+
+        bool IGinService.IsAlive()
+        {
+            return true;
         }
     }
 }

--- a/GinClientApp/ServiceComponent/IGinService.cs
+++ b/GinClientApp/ServiceComponent/IGinService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.ServiceModel;
 using GinClientLibrary;
 
@@ -204,6 +205,13 @@ namespace GinService
         void DownloadFiles(IEnumerable<string> filePaths);
 
         /// <summary>
+        ///     Remove all local content of the files indicated
+        /// </summary>
+        /// <param name="filePaths"></param>
+        [OperationContract]
+        void RemoveLocalContent(IEnumerable<string> filePaths);
+
+        /// <summary>
         ///     Return the output of gin --version
         /// </summary>
         /// <returns></returns>
@@ -231,6 +239,13 @@ namespace GinService
         /// </summary>
         [OperationContract(IsOneWay = true, IsTerminating = true)]
         void EndSession();
+
+        /// <summary>
+        ///     Check if the service is alive
+        /// </summary>
+        /// <returns>true if it is, wcf error otherwise</returns>
+        [OperationContract]
+        bool IsAlive();
     }
 
     [SuppressMessage("ReSharper", "OperationContractWithoutServiceContract")]

--- a/GinShellExtension/Connected Services/GinService/Reference.cs
+++ b/GinShellExtension/Connected Services/GinService/Reference.cs
@@ -165,6 +165,12 @@ namespace GinShellExtension.GinService {
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/DownloadFiles", ReplyAction="http://tempuri.org/IGinService/DownloadFilesResponse")]
         System.Threading.Tasks.Task DownloadFilesAsync(string[] filePaths);
         
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/RemoveLocalContent", ReplyAction="http://tempuri.org/IGinService/RemoveLocalContentResponse")]
+        void RemoveLocalContent(string[] filePaths);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/RemoveLocalContent", ReplyAction="http://tempuri.org/IGinService/RemoveLocalContentResponse")]
+        System.Threading.Tasks.Task RemoveLocalContentAsync(string[] filePaths);
+        
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/GetGinCliVersion", ReplyAction="http://tempuri.org/IGinService/GetGinCliVersionResponse")]
         string GetGinCliVersion();
         
@@ -188,6 +194,12 @@ namespace GinShellExtension.GinService {
         
         [System.ServiceModel.OperationContractAttribute(IsOneWay=true, IsTerminating=true, Action="http://tempuri.org/IGinService/EndSession")]
         System.Threading.Tasks.Task EndSessionAsync();
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/IsAlive", ReplyAction="http://tempuri.org/IGinService/IsAliveResponse")]
+        bool IsAlive();
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IGinService/IsAlive", ReplyAction="http://tempuri.org/IGinService/IsAliveResponse")]
+        System.Threading.Tasks.Task<bool> IsAliveAsync();
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.ServiceModel", "4.0.0.0")]
@@ -434,6 +446,14 @@ namespace GinShellExtension.GinService {
             return base.Channel.DownloadFilesAsync(filePaths);
         }
         
+        public void RemoveLocalContent(string[] filePaths) {
+            base.Channel.RemoveLocalContent(filePaths);
+        }
+        
+        public System.Threading.Tasks.Task RemoveLocalContentAsync(string[] filePaths) {
+            return base.Channel.RemoveLocalContentAsync(filePaths);
+        }
+        
         public string GetGinCliVersion() {
             return base.Channel.GetGinCliVersion();
         }
@@ -464,6 +484,14 @@ namespace GinShellExtension.GinService {
         
         public System.Threading.Tasks.Task EndSessionAsync() {
             return base.Channel.EndSessionAsync();
+        }
+        
+        public bool IsAlive() {
+            return base.Channel.IsAlive();
+        }
+        
+        public System.Threading.Tasks.Task<bool> IsAliveAsync() {
+            return base.Channel.IsAliveAsync();
         }
     }
 }

--- a/GinShellExtension/Connected Services/GinService/service1.wsdl
+++ b/GinShellExtension/Connected Services/GinService/service1.wsdl
@@ -1207,6 +1207,52 @@
       </wsp:All>
     </wsp:ExactlyOne>
   </wsp:Policy>
+  <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_RemoveLocalContent_Input_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+          <sp:Header Name="Sequence" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="SequenceAcknowledgement" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="AckRequested" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="ChannelInstance" Namespace="http://schemas.microsoft.com/ws/2005/02/duplex" />
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing" />
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_RemoveLocalContent_output_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+          <sp:Header Name="Sequence" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="SequenceAcknowledgement" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="AckRequested" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="ChannelInstance" Namespace="http://schemas.microsoft.com/ws/2005/02/duplex" />
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing" />
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
   <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_GetGinCliVersion_Input_policy">
     <wsp:ExactlyOne>
       <wsp:All>
@@ -1323,6 +1369,52 @@
     </wsp:ExactlyOne>
   </wsp:Policy>
   <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_EndSession_Input_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+          <sp:Header Name="Sequence" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="SequenceAcknowledgement" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="AckRequested" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="ChannelInstance" Namespace="http://schemas.microsoft.com/ws/2005/02/duplex" />
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing" />
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_IsAlive_Input_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+          <sp:Header Name="Sequence" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="SequenceAcknowledgement" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="AckRequested" Namespace="http://schemas.xmlsoap.org/ws/2005/02/rm" />
+          <sp:Header Name="ChannelInstance" Namespace="http://schemas.microsoft.com/ws/2005/02/duplex" />
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing" />
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing" />
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body />
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="WSDualHttpBinding_IGinService_IsAlive_output_policy">
     <wsp:ExactlyOne>
       <wsp:All>
         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
@@ -1590,6 +1682,12 @@
   <wsdl:message name="IGinService_DownloadFiles_OutputMessage">
     <wsdl:part name="parameters" element="tns:DownloadFilesResponse" />
   </wsdl:message>
+  <wsdl:message name="IGinService_RemoveLocalContent_InputMessage">
+    <wsdl:part name="parameters" element="tns:RemoveLocalContent" />
+  </wsdl:message>
+  <wsdl:message name="IGinService_RemoveLocalContent_OutputMessage">
+    <wsdl:part name="parameters" element="tns:RemoveLocalContentResponse" />
+  </wsdl:message>
   <wsdl:message name="IGinService_GetGinCliVersion_InputMessage">
     <wsdl:part name="parameters" element="tns:GetGinCliVersion" />
   </wsdl:message>
@@ -1607,6 +1705,12 @@
   </wsdl:message>
   <wsdl:message name="IGinService_EndSession_InputMessage">
     <wsdl:part name="parameters" element="tns:EndSession" />
+  </wsdl:message>
+  <wsdl:message name="IGinService_IsAlive_InputMessage">
+    <wsdl:part name="parameters" element="tns:IsAlive" />
+  </wsdl:message>
+  <wsdl:message name="IGinService_IsAlive_OutputMessage">
+    <wsdl:part name="parameters" element="tns:IsAliveResponse" />
   </wsdl:message>
   <wsdl:message name="IGinService_FileOperationStarted_OutputCallbackMessage">
     <wsdl:part name="parameters" element="tns:FileOperationStarted" />
@@ -1719,6 +1823,10 @@
       <wsdl:input wsaw:Action="http://tempuri.org/IGinService/DownloadFiles" message="tns:IGinService_DownloadFiles_InputMessage" />
       <wsdl:output wsaw:Action="http://tempuri.org/IGinService/DownloadFilesResponse" message="tns:IGinService_DownloadFiles_OutputMessage" />
     </wsdl:operation>
+    <wsdl:operation msc:isInitiating="true" msc:isTerminating="false" name="RemoveLocalContent">
+      <wsdl:input wsaw:Action="http://tempuri.org/IGinService/RemoveLocalContent" message="tns:IGinService_RemoveLocalContent_InputMessage" />
+      <wsdl:output wsaw:Action="http://tempuri.org/IGinService/RemoveLocalContentResponse" message="tns:IGinService_RemoveLocalContent_OutputMessage" />
+    </wsdl:operation>
     <wsdl:operation msc:isInitiating="true" msc:isTerminating="false" name="GetGinCliVersion">
       <wsdl:input wsaw:Action="http://tempuri.org/IGinService/GetGinCliVersion" message="tns:IGinService_GetGinCliVersion_InputMessage" />
       <wsdl:output wsaw:Action="http://tempuri.org/IGinService/GetGinCliVersionResponse" message="tns:IGinService_GetGinCliVersion_OutputMessage" />
@@ -1732,6 +1840,10 @@
     </wsdl:operation>
     <wsdl:operation msc:isInitiating="true" msc:isTerminating="true" name="EndSession">
       <wsdl:input wsaw:Action="http://tempuri.org/IGinService/EndSession" message="tns:IGinService_EndSession_InputMessage" />
+    </wsdl:operation>
+    <wsdl:operation msc:isInitiating="true" msc:isTerminating="false" name="IsAlive">
+      <wsdl:input wsaw:Action="http://tempuri.org/IGinService/IsAlive" message="tns:IGinService_IsAlive_InputMessage" />
+      <wsdl:output wsaw:Action="http://tempuri.org/IGinService/IsAliveResponse" message="tns:IGinService_IsAlive_OutputMessage" />
     </wsdl:operation>
     <wsdl:operation msc:isInitiating="true" msc:isTerminating="false" name="FileOperationStarted">
       <wsdl:output wsaw:Action="http://tempuri.org/IGinService/FileOperationStarted" message="tns:IGinService_FileOperationStarted_OutputCallbackMessage" />
@@ -2016,6 +2128,17 @@
         <soap12:body use="literal" />
       </wsdl:output>
     </wsdl:operation>
+    <wsdl:operation name="RemoveLocalContent">
+      <soap12:operation soapAction="http://tempuri.org/IGinService/RemoveLocalContent" style="document" />
+      <wsdl:input>
+        <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_RemoveLocalContent_Input_policy" />
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_RemoveLocalContent_output_policy" />
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
     <wsdl:operation name="GetGinCliVersion">
       <soap12:operation soapAction="http://tempuri.org/IGinService/GetGinCliVersion" style="document" />
       <wsdl:input>
@@ -2051,6 +2174,17 @@
         <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_EndSession_Input_policy" />
         <soap12:body use="literal" />
       </wsdl:input>
+    </wsdl:operation>
+    <wsdl:operation name="IsAlive">
+      <soap12:operation soapAction="http://tempuri.org/IGinService/IsAlive" style="document" />
+      <wsdl:input>
+        <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_IsAlive_Input_policy" />
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <wsp:PolicyReference URI="#WSDualHttpBinding_IGinService_IsAlive_output_policy" />
+        <soap12:body use="literal" />
+      </wsdl:output>
     </wsdl:operation>
     <wsdl:operation name="FileOperationStarted">
       <soap12:operation soapAction="http://tempuri.org/IGinService/FileOperationStarted" style="document" />

--- a/GinShellExtension/Connected Services/GinService/service2.xsd
+++ b/GinShellExtension/Connected Services/GinService/service2.xsd
@@ -330,6 +330,18 @@
       <xs:sequence />
     </xs:complexType>
   </xs:element>
+  <xs:element name="RemoveLocalContent">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element xmlns:q5="http://schemas.microsoft.com/2003/10/Serialization/Arrays" minOccurs="0" name="filePaths" nillable="true" type="q5:ArrayOfstring" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoveLocalContentResponse">
+    <xs:complexType>
+      <xs:sequence />
+    </xs:complexType>
+  </xs:element>
   <xs:element name="GetGinCliVersion">
     <xs:complexType>
       <xs:sequence />
@@ -365,6 +377,18 @@
   <xs:element name="EndSession">
     <xs:complexType>
       <xs:sequence />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IsAlive">
+    <xs:complexType>
+      <xs:sequence />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IsAliveResponse">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" name="IsAliveResult" type="xs:boolean" />
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="FileOperationStarted">

--- a/GinShellExtension/GinShellExtensionClass.cs
+++ b/GinShellExtension/GinShellExtensionClass.cs
@@ -38,28 +38,17 @@ namespace GinShellExtension
         {
             try
             {
-                var sc = new ServiceController("GinClientService");
-                if (sc.Status != ServiceControllerStatus.Running)
+                var client = ServiceClient.CreateServiceClient(this, 8741);
+                if (!client.IsAlive())
                     return false;
-            }
-            catch
-            {
-                return false;
-            }
 
-            var client = ServiceClient.CreateServiceClient(this, 8741);
-
-            try
-            {
                 var result = client.IsManagedPath(SelectedItemPaths.First());
-                client.EndSession();
                 ((ICommunicationObject) client).Close();
 
                 return result;
             }
             catch
             {
-                ((ICommunicationObject) client).Abort();
                 return false;
             }
         }
@@ -95,7 +84,8 @@ namespace GinShellExtension
         {
             var mItems = new List<ToolStripItem>
             {
-                new ToolStripMenuItem("Download File", null, FileDownload)
+                new ToolStripMenuItem("Download File", null, FileDownload),
+                new ToolStripMenuItem("Remove local contents", null, FileRemove)
             };
 
             return mItems.ToArray();
@@ -134,6 +124,14 @@ namespace GinShellExtension
 
             await client.DownloadFilesAsync(SelectedItemPaths.ToArray());
             ((ICommunicationObject) client).Close();
+        }
+
+        private async void FileRemove(object sender, EventArgs eventArgs)
+        {
+            var client = ServiceClient.CreateServiceClient(this, 8741);
+
+            await client.RemoveLocalContentAsync(SelectedItemPaths.ToArray());
+            ((ICommunicationObject)client).Close();
         }
     }
 }

--- a/GinShellExtension/IconOverlay.cs
+++ b/GinShellExtension/IconOverlay.cs
@@ -44,16 +44,8 @@ namespace GinShellExtension
 
         protected override bool CanShowOverlay(string path, FILE_ATTRIBUTE attributes)
         {
-            try
-            {
-                var sc = new ServiceController("GinClientService");
-                if (sc.Status != ServiceControllerStatus.Running)
-                    return false;
-            }
-            catch
-            {
-                return false;
-            }
+
+            return false; //Disable this for now!
 
             _path = path;
 

--- a/GinShellExtension/ServiceClient.cs
+++ b/GinShellExtension/ServiceClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ServiceModel;
+using System.Xml;
 using GinShellExtension.GinService;
 
 namespace GinShellExtension
@@ -11,7 +12,21 @@ namespace GinShellExtension
             var iContext = new InstanceContext(context);
             var myBinding = new WSDualHttpBinding
             {
-                ClientBaseAddress = new Uri(@"http://localhost:8738/GinService/ShellExtension/" + port)
+                ClientBaseAddress = new Uri(@"http://localhost:8738/GinService/ShellExtension/" + Environment.UserName + "/" + port),
+                MaxBufferPoolSize = int.MaxValue,
+                MaxReceivedMessageSize = int.MaxValue,
+                OpenTimeout = TimeSpan.FromMinutes(1.0),
+                CloseTimeout = TimeSpan.FromMinutes(1.0),
+                SendTimeout = TimeSpan.FromHours(1),
+                ReceiveTimeout = TimeSpan.FromHours(1),
+                ReaderQuotas = new XmlDictionaryReaderQuotas
+                {
+                    MaxArrayLength = int.MaxValue,
+                    MaxBytesPerRead = int.MaxValue,
+                    MaxDepth = int.MaxValue,
+                    MaxNameTableCharCount = int.MaxValue,
+                    MaxStringContentLength = int.MaxValue
+                }
             };
             var endpointIdentity = EndpointIdentity.CreateDnsIdentity("localhost");
             var myEndpoint = new EndpointAddress(new Uri("http://localhost:8733/GinService/"), endpointIdentity);


### PR DESCRIPTION
- Make sure the shell extension is active and checks for the WCF service's presence correctly
- Adds ability to remove local content to the shell extension context menu
- Fixes an issue where some gin actions were done on the mirror directory instead of the actual checkout directory
- Make sure that the shell extension does not kill the WCF service