### PR TITLE
[appveyor] Remove outdated 'install' block

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,15 +5,6 @@ shallow_clone: true
 environment:
     RDP: "no"
 
-install:
-    - ps: |
-        Write-Host "Downloading Microsoft Visual Studio 2017 Installer Projects..."
-        $vsixPath = "$($env:USERPROFILE)\InstallerProjects.vsix"
-        (new-object net.webclient).DownloadFile('https://visualstudioproductteam.gallerycdn.vsassets.io/extensions/visualstudioproductteam/microsoftvisualstudio2017installerprojects/0.8.5/1517363289019/InstallerProjects.vsix', $vsixPath)
-        Write-Host "Installing..."
-        "`"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VSIXInstaller.exe`" /q /a $vsixPath" | out-file ".\install-vsix.cmd" -Encoding ASCII
-        & .\install-vsix.cmd
-
 build_script:
     - nuget restore
     - '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\devenv.exe" GinClientApp.sln /Rebuild Debug /Project Setup\Setup.vdproj'


### PR DESCRIPTION
Previous install section was required to update VS installer extension.
Updated Appveyor env includes it now. This is no longer required.